### PR TITLE
Tokio upgrade, error handling, Client API refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-imap"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Dirkjan Ochtman <dirkjan@ochtman.nl>"]
 description = "Tokio-based IMAP protocol (client, for now) implementation"
 documentation = "https://docs.rs/tokio-imap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ futures-state-stream = "0.1"
 imap-proto = { version = "0.4", path = "../imap-proto" }
 native-tls = "0.1"
 nom = "3.1"
-tokio-core = "0.1"
+tokio = "0.1"
 tokio-io = "0.1"
 tokio-tls = "0.1"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -95,8 +95,8 @@ impl StateStream for ResponseStream {
         };
         if self.done {
             let mut state = self.state.take().unwrap();
-            if self.next_state.is_some() {
-                state.state = self.next_state.take().unwrap();
+            if let Some(next_state) = self.next_state.take() {
+                state.state = next_state;
             }
             let client = Client { transport, state };
             return Ok(Async::Ready(StreamEvent::Done(client)));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -39,7 +39,7 @@ impl Client {
 
     pub fn call(self, cmd: Command) -> ResponseStream {
         let Self { transport, mut state } = self;
-        let request_id = state.request_ids.next().unwrap();
+        let request_id = state.request_ids.next().unwrap(); // safe: never returns Err
         let (cmd_bytes, next_state) = cmd.into_parts();
         let future = transport.send(Request(request_id.clone(), cmd_bytes));
         ResponseStream::new(future, state, request_id, next_state)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,7 +14,7 @@ use tokio_tls::{ConnectAsync, TlsConnectorExt};
 
 use imap_proto::{Request, RequestId, State};
 use imap_proto::builders::command::Command;
-use proto::{ImapCodec, ImapTls, ResponseData};
+use proto::{ImapCodec, ImapTls, ImapTransport, ResponseData};
 
 pub mod builder {
     pub use imap_proto::builders::command::{CommandBuilder, FetchBuilderAttributes,
@@ -24,21 +24,20 @@ pub mod builder {
 }
 
 
-pub struct Client {
-    transport: ImapTls,
-    state: ClientState,
+pub fn connect(server: &str) -> io::Result<ImapConnectFuture> {
+    let addr = (server, 993).to_socket_addrs()?.next().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::Other, format!("no IP addresses found for {}", server))
+    })?;
+    Ok(ImapConnectFuture::TcpConnecting(TcpStream::connect(&addr), server.to_string()))
 }
 
-impl Client {
-    pub fn connect(server: &str) -> io::Result<ImapConnectFuture> {
-        let addr = (server, 993).to_socket_addrs()?.next().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, format!("no IP addresses found for {}", server))
-        })?;
-        Ok(ImapConnectFuture::TcpConnecting(TcpStream::connect(&addr), server.to_string()))
-    }
+pub trait ImapClient {
+    type Transport: ImapTransport;
+    fn into_parts(self) -> (Self::Transport, ClientState);
+    fn rebuild(transport: Self::Transport, state: ClientState) -> Self;
 
-    pub fn call(self, cmd: Command) -> ResponseStream {
-        let Self { transport, mut state } = self;
+    fn call(self, cmd: Command) -> ResponseStream<Self> where Self: ImapClient + Sized {
+        let (transport, mut state) = self.into_parts();
         let request_id = state.request_ids.next().unwrap(); // safe: never returns Err
         let (cmd_bytes, next_state) = cmd.into_parts();
         let future = transport.send(Request(request_id.clone(), cmd_bytes));
@@ -46,17 +45,35 @@ impl Client {
     }
 }
 
-pub struct ResponseStream {
-    future: Option<Send<ImapTls>>,
-    transport: Option<ImapTls>,
+pub struct Client {
+    transport: ImapTls,
+    state: ClientState,
+}
+
+impl ImapClient for Client {
+    type Transport = ImapTls;
+
+    fn into_parts(self) -> (ImapTls, ClientState) {
+        let Self { transport, state } = self;
+        (transport, state)
+    }
+
+    fn rebuild(transport: ImapTls, state: ClientState) -> Client {
+        Client { transport, state }
+    }
+}
+
+pub struct ResponseStream<E> where E: ImapClient {
+    future: Option<Send<E::Transport>>,
+    transport: Option<E::Transport>,
     state: Option<ClientState>,
     request_id: RequestId,
     next_state: Option<State>,
     done: bool,
 }
 
-impl ResponseStream {
-    pub fn new(future: Send<ImapTls>, state: ClientState,
+impl<E> ResponseStream<E> where E: ImapClient {
+    pub fn new(future: Send<E::Transport>, state: ClientState,
                request_id: RequestId, next_state: Option<State>) -> Self {
         Self {
             future: Some(future),
@@ -69,9 +86,9 @@ impl ResponseStream {
     }
 }
 
-impl StateStream for ResponseStream {
+impl<E> StateStream for ResponseStream<E> where E: ImapClient {
     type Item = ResponseData;
-    type State = Client;
+    type State = E;
     type Error = io::Error;
     fn poll(&mut self) -> Poll<StreamEvent<Self::Item, Self::State>, Self::Error> {
         match self.future.take() {
@@ -98,8 +115,7 @@ impl StateStream for ResponseStream {
             if let Some(next_state) = self.next_state.take() {
                 state.state = next_state;
             }
-            let client = Client { transport, state };
-            return Ok(Async::Ready(StreamEvent::Done(client)));
+            return Ok(Async::Ready(StreamEvent::Done(E::rebuild(transport, state))));
         }
         match transport.poll() {
             Ok(Async::Ready(Some(rsp))) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -30,9 +30,11 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn connect(server: &str) -> ImapConnectFuture {
-        let addr = (server, 993).to_socket_addrs().unwrap().next().unwrap();
-        ImapConnectFuture::TcpConnecting(TcpStream::connect(&addr), server.to_string())
+    pub fn connect(server: &str) -> io::Result<ImapConnectFuture> {
+        let addr = (server, 993).to_socket_addrs()?.next().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, format!("no IP addresses found for {}", server))
+        })?;
+        Ok(ImapConnectFuture::TcpConnecting(TcpStream::connect(&addr), server.to_string()))
     }
 
     pub fn call(self, cmd: Command) -> ResponseStream {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -94,7 +94,7 @@ impl StateStream for ResponseStream {
             Some(mut transport) => transport,
         };
         if self.done {
-            let mut state = self.state.take().unwrap();
+            let mut state = self.state.take().unwrap(); // safe: initialized from start
             if let Some(next_state) = self.next_state.take() {
                 state.state = next_state;
             }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -31,8 +31,7 @@ pub struct Client {
 
 impl Client {
     pub fn connect(server: &str) -> ImapConnectFuture {
-        let addr = format!("{}:993", server);
-        let addr = addr.to_socket_addrs().unwrap().next().unwrap();
+        let addr = (server, 993).to_socket_addrs().unwrap().next().unwrap();
         ImapConnectFuture::TcpConnecting(TcpStream::connect(&addr), server.to_string())
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -45,12 +45,12 @@ pub trait ImapClient {
     }
 }
 
-pub struct Client {
+pub struct TlsClient {
     transport: ImapTls,
     state: ClientState,
 }
 
-impl ImapClient for Client {
+impl ImapClient for TlsClient {
     type Transport = ImapTls;
 
     fn into_parts(self) -> (ImapTls, ClientState) {
@@ -58,8 +58,8 @@ impl ImapClient for Client {
         (transport, state)
     }
 
-    fn rebuild(transport: ImapTls, state: ClientState) -> Client {
-        Client { transport, state }
+    fn rebuild(transport: ImapTls, state: ClientState) -> TlsClient {
+        TlsClient { transport, state }
     }
 }
 
@@ -142,7 +142,7 @@ pub enum ImapConnectFuture {
 }
 
 impl Future for ImapConnectFuture {
-    type Item = (Client, ResponseData);
+    type Item = (TlsClient, ResponseData);
     type Error = io::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let mut new = None;
@@ -166,7 +166,7 @@ impl Future for ImapConnectFuture {
         }
         if let ImapConnectFuture::ServerGreeting(ref mut wrapped) = *self {
             let msg = try_ready!(wrapped.as_mut().unwrap().poll()).unwrap();
-            return Ok(Async::Ready((Client {
+            return Ok(Async::Ready((TlsClient {
                 transport: wrapped.take().unwrap(),
                 state: ClientState::new(),
             }, msg)));

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,7 +14,7 @@ use tokio_tls::{ConnectAsync, TlsConnectorExt};
 
 use imap_proto::{Request, RequestId, State};
 use imap_proto::builders::command::Command;
-use proto::{ImapCodec, ImapTransport, ResponseData};
+use proto::{ImapCodec, ImapTls, ResponseData};
 
 pub mod builder {
     pub use imap_proto::builders::command::{CommandBuilder, FetchBuilderAttributes,
@@ -25,7 +25,7 @@ pub mod builder {
 
 
 pub struct Client {
-    transport: ImapTransport,
+    transport: ImapTls,
     state: ClientState,
 }
 
@@ -47,8 +47,8 @@ impl Client {
 }
 
 pub struct ResponseStream {
-    future: Option<Send<ImapTransport>>,
-    transport: Option<ImapTransport>,
+    future: Option<Send<ImapTls>>,
+    transport: Option<ImapTls>,
     state: Option<ClientState>,
     request_id: RequestId,
     next_state: Option<State>,
@@ -56,7 +56,7 @@ pub struct ResponseStream {
 }
 
 impl ResponseStream {
-    pub fn new(future: Send<ImapTransport>, state: ClientState,
+    pub fn new(future: Send<ImapTls>, state: ClientState,
                request_id: RequestId, next_state: Option<State>) -> Self {
         Self {
             future: Some(future),
@@ -122,7 +122,7 @@ impl StateStream for ResponseStream {
 pub enum ImapConnectFuture {
     #[doc(hidden)] TcpConnecting(ConnectFuture, String),
     #[doc(hidden)] TlsHandshake(ConnectAsync<TcpStream>),
-    #[doc(hidden)] ServerGreeting(Option<ImapTransport>),
+    #[doc(hidden)] ServerGreeting(Option<ImapTls>),
 }
 
 impl Future for ImapConnectFuture {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -89,10 +89,10 @@ impl StateStream for ResponseStream {
             },
             None => {},
         }
-        if !self.transport.is_some() {
-            return Ok(Async::NotReady);
-        }
-        let mut transport = self.transport.take().unwrap();
+        let mut transport = match self.transport.take() {
+            None => return Ok(Async::NotReady),
+            Some(mut transport) => transport,
+        };
         if self.done {
             let mut state = self.state.take().unwrap();
             if self.next_state.is_some() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -74,9 +74,8 @@ impl StateStream for ResponseStream {
     type State = Client;
     type Error = io::Error;
     fn poll(&mut self) -> Poll<StreamEvent<Self::Item, Self::State>, Self::Error> {
-        if self.future.is_some() {
-            let mut future = self.future.take().unwrap();
-            match future.poll() {
+        match self.future.take() {
+            Some(mut future) => match future.poll() {
                 Ok(Async::Ready(transport)) => {
                     self.transport = Some(transport);
                 },
@@ -87,7 +86,8 @@ impl StateStream for ResponseStream {
                 Err(e) => {
                     return Err(e);
                 },
-            }
+            },
+            None => {},
         }
         if !self.transport.is_some() {
             return Ok(Async::NotReady);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate futures_state_stream;
 extern crate imap_proto;
 extern crate native_tls;
 extern crate nom;
-extern crate tokio_core;
+extern crate tokio;
 extern crate tokio_io;
 extern crate tokio_tls;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ extern crate tokio_tls;
 pub mod client;
 pub mod proto;
 
-pub use client::Client;
+pub use client::TlsClient;
 
 pub mod types {
     pub use imap_proto::types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ extern crate tokio_tls;
 pub mod client;
 pub mod proto;
 
-pub use client::TlsClient;
+pub use client::{ImapClient, TlsClient};
 
 pub mod types {
     pub use imap_proto::types::*;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -8,7 +8,7 @@ use imap_proto::types::{Request, RequestId, Response};
 use std::io;
 use std::mem;
 
-use tokio_core::net::TcpStream;
+use tokio::net::TcpStream;
 use tokio_io::codec::{Decoder, Encoder, Framed};
 use tokio_tls::TlsStream;
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -48,7 +48,10 @@ impl<'a> Decoder for ImapCodec {
             IResult::Incomplete(_) => {
                 return Ok(None);
             },
-            IResult::Error(err) => panic!("error {} during parsing of {:?}", err, buf),
+            IResult::Error(err) => {
+                return Err(io::Error::new(io::ErrorKind::Other,
+                                          format!("error {} during parsing of {:?}", err, buf)));
+            }
         };
         let raw = buf.split_to(rsp_len);
         self.decode_need_message_bytes = 0;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,5 +1,7 @@
 use bytes::{BufMut, BytesMut};
 
+use futures;
+
 use nom::{IResult, Needed};
 
 use imap_proto;
@@ -12,8 +14,6 @@ use tokio::net::TcpStream;
 use tokio_io::codec::{Decoder, Encoder, Framed};
 use tokio_tls::TlsStream;
 
-
-pub type ImapTransport = Framed<TlsStream<TcpStream>, ImapCodec>;
 
 pub struct ImapCodec {
     decode_need_message_bytes: usize,
@@ -92,4 +92,12 @@ impl ResponseData {
     pub fn parsed(&self) -> &Response {
         unsafe { mem::transmute(&self.response) }
     }
+}
+
+pub type ImapTls = Framed<TlsStream<TcpStream>, ImapCodec>;
+
+impl ImapTransport for ImapTls {}
+
+pub trait ImapTransport: futures::Stream<Item = ResponseData, Error = io::Error> +
+                         futures::Sink<SinkItem = Request, SinkError = io::Error> {
 }


### PR DESCRIPTION
@jonhoo, @sanmai-NL, others: please review.

- Upgrades from tokio-core to the new tokio reform
- Handle connecting without string formatting the server address
- Improves error handling to have fewer `unwrap()` calls (and annotate the safe ones)
- Decouple `ResponseStream` from `Client` type
- Rename `Client` to `TlsClient`, move behavior into a trait called `ImapClient`