### PR TITLE
Upgrade nom to 4.0

### DIFF
--- a/imap-proto/Cargo.toml
+++ b/imap-proto/Cargo.toml
@@ -15,4 +15,4 @@ maintenance = { status = "actively-developed" }
 travis-ci = { repository = "djc/tokio-imap" }
 
 [dependencies]
-nom = "3.1"
+nom = "4.0"

--- a/imap-proto/src/parser.rs
+++ b/imap-proto/src/parser.rs
@@ -80,19 +80,19 @@ named!(literal<&[u8]>, do_parse!(
 named!(string<&[u8]>, alt!(quoted | literal));
 
 named!(status_ok<Status>, map!(tag_no_case!("OK"),
-    |s| Status::Ok
+    |_s| Status::Ok
 ));
 named!(status_no<Status>, map!(tag_no_case!("NO"),
-    |s| Status::No
+    |_s| Status::No
 ));
 named!(status_bad<Status>, map!(tag_no_case!("BAD"),
-    |s| Status::Bad
+    |_s| Status::Bad
 ));
 named!(status_preauth<Status>, map!(tag_no_case!("PREAUTH"),
-    |s| Status::PreAuth
+    |_s| Status::PreAuth
 ));
 named!(status_bye<Status>, map!(tag_no_case!("BYE"),
-    |s| Status::Bye
+    |_s| Status::Bye
 ));
 
 named!(status<Status>, alt!(
@@ -448,7 +448,7 @@ named!(address<Address>, do_parse!(
 ));
 
 named!(opt_addresses<Option<Vec<Address>>>, alt!(
-    map!(tag_s!("NIL"), |s| None) |
+    map!(tag_s!("NIL"), |_s| None) |
     do_parse!(
         tag_s!("(") >>
         addrs: many1!(address) >>

--- a/tokio-imap/Cargo.toml
+++ b/tokio-imap/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.1"
 futures-state-stream = "0.1"
 imap-proto = { version = "0.4", path = "../imap-proto" }
 native-tls = "0.1"
-nom = "3.1"
+nom = "4.0"
 tokio = "0.1"
 tokio-codec = "0.1"
 tokio-tls = "0.1"


### PR DESCRIPTION
Note: Relevant breaking changes:

* IResult is now an alias for std Result,
  with Incomplete being a Err(nom::Err::Incomplete)

* Incomplete now contains only the additional needed size
  instead of the total expected size

There is **one failing test** that I couldn't figure out right away.