### PR TITLE
imap-proto/parser: add HIGHESTMODSEQ status attribute

### DIFF
--- a/imap-proto/src/parser.rs
+++ b/imap-proto/src/parser.rs
@@ -364,6 +364,7 @@ named!(mailbox_data_lsub<Response>, do_parse!(
 // so that it can return a valid enum object instead of just a key.
 named!(status_att<StatusAttribute>, do_parse!(
     key: alt!(
+        tag_s!("HIGHESTMODSEQ") |
         tag_s!("MESSAGES") |
         tag_s!("RECENT") |
         tag_s!("UIDNEXT") |
@@ -373,6 +374,7 @@ named!(status_att<StatusAttribute>, do_parse!(
     tag_s!(" ") >>
     val: number >>
     (match key {
+        b"HIGHESTMODSEQ" => StatusAttribute::HighestModSeq(val),
         b"MESSAGES" => StatusAttribute::Messages(val),
         b"RECENT" => StatusAttribute::Recent(val),
         b"UIDNEXT" => StatusAttribute::UidNext(val),

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -62,6 +62,7 @@ pub enum StatusAttribute {
     UidNext(u32),
     UidValidity(u32),
     Unseen(u32),
+    HighestModSeq(u32),
 }
 
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
the HIGHESTMODSEQ attribute is specified in
https://tools.ietf.org/html/rfc4551. although this doesn't aim to
implement that rfc to any level of completion, i needed this basic level
of support because some servers (dovecot in my case) always send
HIGHESTMODSEQ-responses with STATUS lines