### PR TITLE
Implemented missing response codes.

### DIFF
--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -92,6 +92,16 @@ named!(flag_perm<&str>, alt!(
     flag
 ));
 
+named!(resp_text_code_alert<ResponseCode>, do_parse!(
+    tag_s!("ALERT") >>
+    (ResponseCode::Alert)
+));
+
+named!(resp_text_code_parse<ResponseCode>, do_parse!(
+    tag_s!("PARSE") >>
+    (ResponseCode::Parse)
+));
+
 named!(resp_text_code_permanent_flags<ResponseCode>, do_parse!(
     tag_s!("PERMANENTFLAGS (") >>
     elements: opt!(do_parse!(
@@ -151,6 +161,8 @@ named!(resp_text_code_unseen<ResponseCode>, do_parse!(
 named!(resp_text_code<ResponseCode>, do_parse!(
     tag_s!("[") >>
     coded: alt!(
+        resp_text_code_alert |
+        resp_text_code_parse |
         resp_text_code_permanent_flags |
         resp_text_code_uid_validity |
         resp_text_code_uid_next |

--- a/imap-proto/src/parser/rfc3501.rs
+++ b/imap-proto/src/parser/rfc3501.rs
@@ -769,5 +769,14 @@ mod tests {
             },
             rsp @ _ => panic!("unexpected response {:?}", rsp)
         }
+
+        match parse_response(b"* NO [BADCHARSET ()] error\r\n") {
+            Ok((_, Response::Data {
+                status: Status::No,
+                code: None,
+                information: Some("[BADCHARSET ()] error")
+            })) => {}
+            rsp @ _ => panic!("unexpected response {:?}", rsp)
+        }
     }
 }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -46,6 +46,7 @@ pub enum Status {
 #[derive(Debug, Eq, PartialEq)]
 pub enum ResponseCode<'a> {
     Alert,
+    Capabilities(Vec<&'a str>),
     HighestModSeq(u64), // RFC 4551, section 3.1.1
     Parse,
     PermanentFlags(Vec<&'a str>),

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -46,6 +46,7 @@ pub enum Status {
 #[derive(Debug, Eq, PartialEq)]
 pub enum ResponseCode<'a> {
     Alert,
+    BadCharset(Option<Vec<&'a str>>),
     Capabilities(Vec<&'a str>),
     HighestModSeq(u64), // RFC 4551, section 3.1.1
     Parse,

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -45,7 +45,9 @@ pub enum Status {
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum ResponseCode<'a> {
+    Alert,
     HighestModSeq(u64), // RFC 4551, section 3.1.1
+    Parse,
     PermanentFlags(Vec<&'a str>),
     ReadOnly,
     ReadWrite,


### PR DESCRIPTION
Implemented ALERT, BADCHARSET, CAPABILITY, and PARSE response codes. See section 7.1 of rfc 3501.