### PR TITLE
Add support for gmail x-gm-thrid extension

### DIFF
--- a/imap-proto/src/builders/command.rs
+++ b/imap-proto/src/builders/command.rs
@@ -255,6 +255,7 @@ fn push_attr(cmd: &mut Vec<u8>, attr: Attribute) {
             Attribute::Uid => "UID",
             Attribute::GmailLabels => "X-GM-LABELS",
             Attribute::GmailMsgId => "X-GM-MSGID",
+            Attribute::GmailThrId => "X-GM-THRID",
         }
         .as_bytes(),
     );

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -378,6 +378,7 @@ fn mailbox_data(i: &[u8]) -> IResult<&[u8], MailboxDatum> {
         mailbox_data_search,
         gmail::mailbox_data_gmail_labels,
         gmail::mailbox_data_gmail_msgid,
+        gmail::mailbox_data_gmail_thrid,
         rfc5256::mailbox_data_sort,
     ))(i)
 }
@@ -574,6 +575,7 @@ fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue> {
         msg_att_uid,
         gmail::msg_att_gmail_labels,
         gmail::msg_att_gmail_msgid,
+        gmail::msg_att_gmail_thrid,
     ))(i)
 }
 

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -238,6 +238,7 @@ pub enum MailboxDatum<'a> {
     },
     GmailLabels(Vec<Cow<'a, str>>),
     GmailMsgId(u64),
+    GmailThrId(u64),
 }
 
 impl<'a> MailboxDatum<'a> {
@@ -282,6 +283,7 @@ impl<'a> MailboxDatum<'a> {
                 MailboxDatum::GmailLabels(labels.into_iter().map(to_owned_cow).collect())
             }
             MailboxDatum::GmailMsgId(msgid) => MailboxDatum::GmailMsgId(msgid),
+            MailboxDatum::GmailThrId(thrid) => MailboxDatum::GmailThrId(thrid),
         }
     }
 }
@@ -318,6 +320,7 @@ pub enum Attribute {
     /// https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels
     GmailLabels,
     GmailMsgId,
+    GmailThrId,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -355,6 +358,7 @@ pub enum AttributeValue<'a> {
     /// https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels
     GmailLabels(Vec<Cow<'a, str>>),
     GmailMsgId(u64),
+    GmailThrId(u64),
 }
 
 impl<'a> AttributeValue<'a> {
@@ -385,6 +389,7 @@ impl<'a> AttributeValue<'a> {
                 AttributeValue::GmailLabels(v.into_iter().map(to_owned_cow).collect())
             }
             AttributeValue::GmailMsgId(v) => AttributeValue::GmailMsgId(v),
+            AttributeValue::GmailThrId(v) => AttributeValue::GmailThrId(v),
         }
     }
 }


### PR DESCRIPTION
Gmail provides a thread ID to associate groups of messages in the same manner as in the Gmail web interface.

Retrieval of this thread ID is supported via the [`X-GM-THRID`](https://developers.google.com/workspace/gmail/imap/imap-extensions#access_to_the_thread_id_x-gm-thrid) attribute on the FETCH command

I have updated the imap-proto to local path for https://github.com/jonhoo/rust-imap, updated the codebase and managed to fetch the thread id from gmail.

Once this PR is included as part of a release, I will update https://github.com/jonhoo/rust-imap/pull/312 with the matching release version.

Thanks