### PR TITLE
fix(parser): allow trailing whitespace before closing parenthesis #190

### DIFF
--- a/imap-proto/src/parser/core.rs
+++ b/imap-proto/src/parser/core.rs
@@ -1,7 +1,7 @@
 use nom::{
     branch::alt,
     bytes::streaming::{escaped, tag, tag_no_case, take, take_while, take_while1},
-    character::streaming::{char, digit1, one_of},
+    character::streaming::{char, digit1, one_of, space0},
     combinator::{map, map_res, opt},
     multi::{separated_list0, separated_list1},
     sequence::{delimited, preceded, tuple},
@@ -204,7 +204,13 @@ where
     F: FnMut(&'a [u8]) -> IResult<&'a [u8], O, E>,
     E: nom::error::ParseError<&'a [u8]>,
 {
-    delimited(char('('), separated_list1(char(' '), f), char(')'))
+    delimited(
+        char('('),
+        separated_list1(char(' '), f),
+        // Targeted lenience: Some real-world IMAP servers
+        // insert extra whitespace before the closing parenthesis.
+        tuple((space0, char(')'))),
+    )
 }
 
 pub fn parenthesized_list<'a, F, O, E>(f: F) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Vec<O>, E>

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -681,6 +681,13 @@ fn test_incomplete_fetch() {
 }
 
 #[test]
+fn test_fetch_response_whitespace_tolerance() {
+    // Allow extra whitespace before the closing parenthesis.
+    let input = b"* 11784 FETCH (UID 87567 INTERNALDATE \"06-May-2023 18:48:30 +0200\" RFC822.SIZE 5799845 )\r\n";
+    assert!(parse_response(input).is_ok());
+}
+
+#[test]
 fn test_continuation() {
     // regular RFC compliant
     match parse_response(b"+ \r\n") {


### PR DESCRIPTION
Some real-world IMAP servers include extra whitespace before the closing parenthesis. This change makes the parser more robust by allowing zero or more spaces.