### PR TITLE
chore: bump imap-proto to v0.16.7

### DIFF
--- a/imap-proto/Cargo.toml
+++ b/imap-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imap-proto"
-version = "0.16.6"
+version = "0.16.7"
 edition = "2021"
 rust-version = "1.61"
 description = "IMAP protocol parser and data structures"


### PR DESCRIPTION
Upgraded imap-proto to 0.16.7