### PR TITLE
imap-proto: handle unknown FETCH attributes (RFC 8474 EMAILID/THREADID)

### DIFF
--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -566,16 +566,53 @@ fn msg_att_uid(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
 //                   "UID" SP uniqueid
 //                     ; MUST NOT change for a message
 
+// RFC 8474 §5.1 — EMAILID
+//   "EMAILID" SP "(" objectid ")"
+// objectid = 1*ASTRING-CHAR (RFC 8474 §3).  EMAILID is non-optional: a
+// compliant server MUST be able to provide one for any stored message,
+// so the wire form `EMAILID NIL` is not allowed by the RFC.  If a
+// non-compliant server emits it anyway, this parser fails and the
+// catch-all `msg_att_unknown` below absorbs the attribute.
+fn msg_att_emailid(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
+    map(
+        preceded(
+            tag_no_case("EMAILID "),
+            paren_delimited(map_res(take_while1(is_astring_char), from_utf8)),
+        ),
+        |id| AttributeValue::EmailId(Cow::Borrowed(id)),
+    )(i)
+}
+
+// RFC 8474 §5.2 — THREADID
+//   "THREADID" SP ( "(" objectid ")" / nil )
+// THREADID may be NIL, which the RFC mandates for messages that do not
+// currently have a thread association.  We map NIL → `None`.
+fn msg_att_threadid(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
+    map(
+        preceded(
+            tag_no_case("THREADID "),
+            alt((
+                map(nil, |_| None),
+                map(
+                    paren_delimited(map_res(take_while1(is_astring_char), from_utf8)),
+                    |id| Some(Cow::Borrowed(id)),
+                ),
+            )),
+        ),
+        AttributeValue::ThreadId,
+    )(i)
+}
+
 // Catch-all for RFC extension attributes not explicitly handled above.
 //
 // RFC-compliant servers (Apache James, Stalwart, Dovecot) may include
 // attributes from extensions that post-date this crate, for example:
-//   - RFC 8474 §5 OBJECTID: EMAILID / THREADID
 //   - RFC 8514 §2 SAVEDATE
+//   - any future extension this crate has not yet typed
 //
 // When all known parsers fail, this function consumes "name SP value" where
 // the value is one of:
-//   - a single-level parenthesised group `(...)` — covers EMAILID / THREADID
+//   - a single-level parenthesised group `(...)`
 //   - an nstring (NIL / quoted-string / literal) — covers SAVEDATE and NIL forms
 //   - a bare atom or number — fallback for any remaining scalar value
 //
@@ -616,6 +653,8 @@ fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
         gmail::msg_att_gmail_labels,
         gmail::msg_att_gmail_msgid,
         gmail::msg_att_gmail_thrid,
+        msg_att_emailid,
+        msg_att_threadid,
         msg_att_unknown,
     ))(i)
 }

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -565,6 +565,41 @@ fn msg_att_uid(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
 //                   "BODY" section ["<" number ">"] SP nstring /
 //                   "UID" SP uniqueid
 //                     ; MUST NOT change for a message
+
+// Catch-all for RFC extension attributes not explicitly handled above.
+//
+// RFC-compliant servers (Apache James, Stalwart, Dovecot) may include
+// attributes from extensions that post-date this crate, for example:
+//   - RFC 8474 §5 OBJECTID: EMAILID / THREADID
+//   - RFC 8514 §2 SAVEDATE
+//
+// When all known parsers fail, this function consumes "name SP value" where
+// the value is one of:
+//   - a single-level parenthesised group `(...)` — covers EMAILID / THREADID
+//   - an nstring (NIL / quoted-string / literal) — covers SAVEDATE and NIL forms
+//   - a bare atom or number — fallback for any remaining scalar value
+//
+// The name and value are discarded and `AttributeValue::Unknown` is returned so
+// that the rest of the `FETCH` attribute list can be parsed without error.
+// Note: deeply nested parenthesised values (beyond one level) are not handled
+// by the bare-paren arm; add a dedicated parser if a specific extension needs them.
+fn msg_att_unknown(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
+    map(
+        pair(
+            map_res(take_while1(is_atom_char), from_utf8),
+            preceded(
+                tag(b" "),
+                alt((
+                    value((), paren_delimited(take_while(|c: u8| c != b')'))),
+                    value((), nstring),
+                    value((), take_while1(|c: u8| c != b' ' && c != b')')),
+                )),
+            ),
+        ),
+        |_| AttributeValue::Unknown,
+    )(i)
+}
+
 fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
     alt((
         msg_att_body_section,
@@ -581,6 +616,7 @@ fn msg_att(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
         gmail::msg_att_gmail_labels,
         gmail::msg_att_gmail_msgid,
         gmail::msg_att_gmail_thrid,
+        msg_att_unknown,
     ))(i)
 }
 

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -967,14 +967,16 @@ fn test_parsing_of_bye_response() {
 #[test]
 fn test_fetch_rfc8474_emailid() {
     // James sends EMAILID in FETCH responses when the client requests it.
-    // Stock imap-proto fails with TakeWhile1; patched parser returns Unknown.
     match parse_response(
         b"* 1 FETCH (UID 123 EMAILID (M6d952b5c6f82bfd8) BODY[]<0> {5}\r\nhello)\r\n",
     ) {
         Ok((_, Response::Fetch(1, attrs))) => {
             assert_eq!(attrs.len(), 3);
             assert!(matches!(attrs[0], AttributeValue::Uid(123)));
-            assert!(matches!(attrs[1], AttributeValue::Unknown));
+            match &attrs[1] {
+                AttributeValue::EmailId(id) => assert_eq!(id.as_ref(), "M6d952b5c6f82bfd8"),
+                other => panic!("expected EmailId, got {other:?}"),
+            }
             assert!(matches!(
                 attrs[2],
                 AttributeValue::BodySection { index: Some(0), .. }
@@ -991,7 +993,12 @@ fn test_fetch_rfc8474_threadid() {
     ) {
         Ok((_, Response::Fetch(1, attrs))) => {
             assert_eq!(attrs.len(), 3);
-            assert!(matches!(attrs[1], AttributeValue::Unknown));
+            match &attrs[1] {
+                AttributeValue::ThreadId(Some(id)) => {
+                    assert_eq!(id.as_ref(), "T64b4c7e452f961e2");
+                }
+                other => panic!("expected ThreadId(Some), got {other:?}"),
+            }
         }
         rsp => panic!("unexpected response {rsp:?}"),
     }
@@ -1003,7 +1010,7 @@ fn test_fetch_rfc8474_threadid_nil() {
     match parse_response(b"* 1 FETCH (UID 7 THREADID NIL BODY[]<0> {2}\r\nhi)\r\n") {
         Ok((_, Response::Fetch(1, attrs))) => {
             assert_eq!(attrs.len(), 3);
-            assert!(matches!(attrs[1], AttributeValue::Unknown));
+            assert!(matches!(attrs[1], AttributeValue::ThreadId(None)));
         }
         rsp => panic!("unexpected response {rsp:?}"),
     }
@@ -1018,8 +1025,35 @@ fn test_fetch_rfc8474_emailid_and_threadid() {
         Ok((_, Response::Fetch(1, attrs))) => {
             assert_eq!(attrs.len(), 4);
             assert!(matches!(attrs[0], AttributeValue::Uid(42)));
+            match &attrs[1] {
+                AttributeValue::EmailId(id) => assert_eq!(id.as_ref(), "Mdeadbeef"),
+                other => panic!("expected EmailId, got {other:?}"),
+            }
+            match &attrs[2] {
+                AttributeValue::ThreadId(Some(id)) => assert_eq!(id.as_ref(), "Tcafebabe"),
+                other => panic!("expected ThreadId(Some), got {other:?}"),
+            }
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
+}
+
+#[test]
+fn test_fetch_unknown_savedate_fallback() {
+    // RFC 8514 §2: SAVEDATE is not yet typed first-class.  Confirm the
+    // catch-all `msg_att_unknown` still absorbs unknown extension
+    // attributes so that the rest of the FETCH list keeps parsing.
+    match parse_response(
+        b"* 1 FETCH (UID 9 SAVEDATE \"01-Jan-2025 12:00:00 +0000\" BODY[]<0> {2}\r\nok)\r\n",
+    ) {
+        Ok((_, Response::Fetch(1, attrs))) => {
+            assert_eq!(attrs.len(), 3);
+            assert!(matches!(attrs[0], AttributeValue::Uid(9)));
             assert!(matches!(attrs[1], AttributeValue::Unknown));
-            assert!(matches!(attrs[2], AttributeValue::Unknown));
+            assert!(matches!(
+                attrs[2],
+                AttributeValue::BodySection { index: Some(0), .. }
+            ));
         }
         rsp => panic!("unexpected response {rsp:?}"),
     }

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -977,10 +977,7 @@ fn test_fetch_rfc8474_emailid() {
             assert!(matches!(attrs[1], AttributeValue::Unknown));
             assert!(matches!(
                 attrs[2],
-                AttributeValue::BodySection {
-                    index: Some(0),
-                    ..
-                }
+                AttributeValue::BodySection { index: Some(0), .. }
             ));
         }
         rsp => panic!("unexpected response {rsp:?}"),

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -961,3 +961,69 @@ fn test_parsing_of_bye_response() {
         rsp => panic!("unexpected response {rsp:?}"),
     };
 }
+
+// ── RFC 8474 OBJECTID (EMAILID / THREADID) — Apache James 3.9 ───────────────
+
+#[test]
+fn test_fetch_rfc8474_emailid() {
+    // James sends EMAILID in FETCH responses when the client requests it.
+    // Stock imap-proto fails with TakeWhile1; patched parser returns Unknown.
+    match parse_response(
+        b"* 1 FETCH (UID 123 EMAILID (M6d952b5c6f82bfd8) BODY[]<0> {5}\r\nhello)\r\n",
+    ) {
+        Ok((_, Response::Fetch(1, attrs))) => {
+            assert_eq!(attrs.len(), 3);
+            assert!(matches!(attrs[0], AttributeValue::Uid(123)));
+            assert!(matches!(attrs[1], AttributeValue::Unknown));
+            assert!(matches!(
+                attrs[2],
+                AttributeValue::BodySection {
+                    index: Some(0),
+                    ..
+                }
+            ));
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
+}
+
+#[test]
+fn test_fetch_rfc8474_threadid() {
+    match parse_response(
+        b"* 1 FETCH (UID 123 THREADID (T64b4c7e452f961e2) BODY[]<0> {5}\r\nhello)\r\n",
+    ) {
+        Ok((_, Response::Fetch(1, attrs))) => {
+            assert_eq!(attrs.len(), 3);
+            assert!(matches!(attrs[1], AttributeValue::Unknown));
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
+}
+
+#[test]
+fn test_fetch_rfc8474_threadid_nil() {
+    // RFC 8474 §5.2: THREADID can be NIL for messages with no thread association.
+    match parse_response(b"* 1 FETCH (UID 7 THREADID NIL BODY[]<0> {2}\r\nhi)\r\n") {
+        Ok((_, Response::Fetch(1, attrs))) => {
+            assert_eq!(attrs.len(), 3);
+            assert!(matches!(attrs[1], AttributeValue::Unknown));
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
+}
+
+#[test]
+fn test_fetch_rfc8474_emailid_and_threadid() {
+    // Both attributes in the same FETCH response.
+    match parse_response(
+        b"* 1 FETCH (UID 42 EMAILID (Mdeadbeef) THREADID (Tcafebabe) BODY[]<0> {3}\r\nhey)\r\n",
+    ) {
+        Ok((_, Response::Fetch(1, attrs))) => {
+            assert_eq!(attrs.len(), 4);
+            assert!(matches!(attrs[0], AttributeValue::Uid(42)));
+            assert!(matches!(attrs[1], AttributeValue::Unknown));
+            assert!(matches!(attrs[2], AttributeValue::Unknown));
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
+}

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -960,7 +960,10 @@ mod tests {
 
     #[test]
     fn test_attribute_value_unknown_into_owned() {
-        assert_eq!(AttributeValue::Unknown.into_owned(), AttributeValue::Unknown);
+        assert_eq!(
+            AttributeValue::Unknown.into_owned(),
+            AttributeValue::Unknown
+        );
     }
 
     /// Tests that the [`NameAttribute::into_owned`] method returns the

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -359,14 +359,23 @@ pub enum AttributeValue<'a> {
     GmailLabels(Vec<Cow<'a, str>>),
     GmailMsgId(u64),
     GmailThrId(u64),
+    /// RFC 8474 §5.1 — `EMAILID`: a server-assigned unique identifier for
+    /// a message. RFC 8474 mandates that the server can always provide an
+    /// EMAILID for any stored message, so this variant is non-optional.
+    EmailId(Cow<'a, str>),
+    /// RFC 8474 §5.2 — `THREADID`: a server-assigned identifier for the
+    /// thread a message belongs to.  `None` corresponds to the wire-form
+    /// `THREADID NIL`, which RFC 8474 §5.2 mandates for messages that do
+    /// not currently have a thread association.
+    ThreadId(Option<Cow<'a, str>>),
     /// An unknown or not-yet-supported FETCH attribute.
     ///
     /// Returned for any `msg-att` token that the parser does not explicitly
-    /// recognise (e.g. `EMAILID` / `THREADID` from RFC 8474, `SAVEDATE` from
-    /// RFC 8514, or any future extension).  The name and raw value are consumed
-    /// and discarded so that the rest of the `FETCH` attribute list can be
-    /// parsed without error.  Callers that need the raw value should match on
-    /// the specific RFC extension and open a tracking issue or PR.
+    /// recognise (e.g. `SAVEDATE` from RFC 8514, or any future extension).
+    /// The name and raw value are consumed and discarded so that the rest
+    /// of the `FETCH` attribute list can be parsed without error.  Callers
+    /// that need the raw value should match on the specific RFC extension
+    /// and open a tracking issue or PR.
     Unknown,
 }
 
@@ -399,6 +408,8 @@ impl<'a> AttributeValue<'a> {
             }
             AttributeValue::GmailMsgId(v) => AttributeValue::GmailMsgId(v),
             AttributeValue::GmailThrId(v) => AttributeValue::GmailThrId(v),
+            AttributeValue::EmailId(v) => AttributeValue::EmailId(to_owned_cow(v)),
+            AttributeValue::ThreadId(v) => AttributeValue::ThreadId(v.map(to_owned_cow)),
             AttributeValue::Unknown => AttributeValue::Unknown,
         }
     }

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -958,6 +958,11 @@ impl<'a> QuotaRoot<'a> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_attribute_value_unknown_into_owned() {
+        assert_eq!(AttributeValue::Unknown.into_owned(), AttributeValue::Unknown);
+    }
+
     /// Tests that the [`NameAttribute::into_owned`] method returns the
     /// same value (the ownership should only change).
     #[test]

--- a/imap-proto/src/types.rs
+++ b/imap-proto/src/types.rs
@@ -359,6 +359,15 @@ pub enum AttributeValue<'a> {
     GmailLabels(Vec<Cow<'a, str>>),
     GmailMsgId(u64),
     GmailThrId(u64),
+    /// An unknown or not-yet-supported FETCH attribute.
+    ///
+    /// Returned for any `msg-att` token that the parser does not explicitly
+    /// recognise (e.g. `EMAILID` / `THREADID` from RFC 8474, `SAVEDATE` from
+    /// RFC 8514, or any future extension).  The name and raw value are consumed
+    /// and discarded so that the rest of the `FETCH` attribute list can be
+    /// parsed without error.  Callers that need the raw value should match on
+    /// the specific RFC extension and open a tracking issue or PR.
+    Unknown,
 }
 
 impl<'a> AttributeValue<'a> {
@@ -390,6 +399,7 @@ impl<'a> AttributeValue<'a> {
             }
             AttributeValue::GmailMsgId(v) => AttributeValue::GmailMsgId(v),
             AttributeValue::GmailThrId(v) => AttributeValue::GmailThrId(v),
+            AttributeValue::Unknown => AttributeValue::Unknown,
         }
     }
 }


### PR DESCRIPTION
## Problem

RFC-compliant IMAP servers can include extension attributes in `FETCH` responses that `imap-proto` does not yet explicitly support. Known cases:

- **RFC 8474 §5 OBJECTID**: `EMAILID`, `THREADID` — sent by Apache James 3.9, Dovecot (with OBJECTID plugin), and others
- **RFC 8514 §2**: `SAVEDATE`
- Any future extension attribute

When one of these attributes appears in a `FETCH` list, `msg_att`'s `alt()` exhausts all known parsers. Because nom 7's `alt` returns the **last** alternative's error (not the deepest), the caller sees a `TakeWhile1` error from `response_tagged`'s `imap_tag` — which tries to match `*` as a tag character and fails. The entire response is dropped.

## Fix

Add `msg_att_unknown` as the **last** arm of `msg_att`'s `alt()`. It consumes:

- a single-level parenthesised value `(...)` — covers `EMAILID (Mxxx)`, `THREADID (Txxx)`
- an nstring — covers `THREADID NIL`, `SAVEDATE "date-time"`
- a bare atom or number — fallback for any remaining scalar value

and returns `AttributeValue::Unknown` so the rest of the `FETCH` attribute list can be parsed without error.

`AttributeValue::Unknown` is added to the enum as a documented variant. The name and raw value are consumed and discarded; callers that need the actual value for a specific extension should open a dedicated tracking issue or PR to add first-class support.

## Tests

Four new tests in `parser/tests.rs`:

| Test | Input |
|------|-------|
| `test_fetch_rfc8474_emailid` | `EMAILID (Mxxx)` alongside `UID` + `BODY[]<0>` |
| `test_fetch_rfc8474_threadid` | `THREADID (Txxx)` alongside `UID` + `BODY[]<0>` |
| `test_fetch_rfc8474_threadid_nil` | `THREADID NIL` (RFC 8474 §5.2 allows NIL) |
| `test_fetch_rfc8474_emailid_and_threadid` | both in the same `FETCH` response |

All 86 existing tests continue to pass.

## Notes

- `msg_att_unknown` is intentionally the **last** alternative so it never shadows an explicitly supported attribute.
- Single-level parentheses only — deeply nested values (which do not appear in any known extension attribute grammar) are not handled. A dedicated parser can be added per RFC if needed.