### PR TITLE
fix(parser): tolerate 8-bit bytes in strings and literals

### DIFF
--- a/imap-proto/Cargo.toml
+++ b/imap-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imap-proto"
-version = "0.16.7"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.61"
 description = "IMAP protocol parser and data structures"

--- a/imap-proto/src/parser/core.rs
+++ b/imap-proto/src/parser/core.rs
@@ -8,6 +8,7 @@ use nom::{
     IResult,
 };
 
+use std::borrow::Cow;
 use std::str::{from_utf8, FromStr};
 
 // ----- number -----
@@ -61,9 +62,17 @@ pub fn string(i: &[u8]) -> IResult<&[u8], &[u8]> {
     alt((quoted, literal))(i)
 }
 
-// string bytes as utf8
-pub fn string_utf8(i: &[u8]) -> IResult<&[u8], &str> {
-    map_res(string, from_utf8)(i)
+#[inline]
+fn lossy_str(bytes: &[u8]) -> Cow<'_, str> {
+    String::from_utf8_lossy(bytes)
+}
+
+// string bytes as utf8 — falls back to lossy decoding when the literal
+// or quoted contents include non-UTF-8 bytes (e.g. Latin-1 / ISO-8859-9
+// MIME filenames in BODYSTRUCTURE responses). Strict from_utf8 would
+// fail, breaking the entire response stream on a single bad mail.
+pub fn string_utf8(i: &[u8]) -> IResult<&[u8], Cow<'_, str>> {
+    map(string, lossy_str)(i)
 }
 
 // quoted = DQUOTE *QUOTED-CHAR DQUOTE
@@ -79,9 +88,9 @@ pub fn quoted(i: &[u8]) -> IResult<&[u8], &[u8]> {
     )(i)
 }
 
-// quoted bytes as utf8
-pub fn quoted_utf8(i: &[u8]) -> IResult<&[u8], &str> {
-    map_res(quoted, from_utf8)(i)
+// quoted bytes as utf8 — lossy, see comment on string_utf8.
+pub fn quoted_utf8(i: &[u8]) -> IResult<&[u8], Cow<'_, str>> {
+    map(quoted, lossy_str)(i)
 }
 
 // quoted-specials = DQUOTE / "\"
@@ -108,9 +117,9 @@ pub fn astring(i: &[u8]) -> IResult<&[u8], &[u8]> {
     alt((take_while1(is_astring_char), string))(i)
 }
 
-// astring bytes as utf8
-pub fn astring_utf8(i: &[u8]) -> IResult<&[u8], &str> {
-    map_res(astring, from_utf8)(i)
+// astring bytes as utf8 — lossy, see comment on string_utf8.
+pub fn astring_utf8(i: &[u8]) -> IResult<&[u8], Cow<'_, str>> {
+    map(astring, lossy_str)(i)
 }
 
 // ASTRING-CHAR = ATOM-CHAR / resp-specials
@@ -152,8 +161,8 @@ pub fn nstring(i: &[u8]) -> IResult<&[u8], Option<&[u8]>> {
     alt((map(nil, |_| None), map(string, Some)))(i)
 }
 
-// nstring bytes as utf8
-pub fn nstring_utf8(i: &[u8]) -> IResult<&[u8], Option<&str>> {
+// nstring bytes as utf8 — lossy, see comment on string_utf8.
+pub fn nstring_utf8(i: &[u8]) -> IResult<&[u8], Option<Cow<'_, str>>> {
     alt((map(nil, |_| None), map(string_utf8, Some)))(i)
 }
 
@@ -164,9 +173,9 @@ pub fn nil(i: &[u8]) -> IResult<&[u8], &[u8]> {
 
 // ----- text -----
 
-// text = 1*TEXT-CHAR
-pub fn text(i: &[u8]) -> IResult<&[u8], &str> {
-    map_res(take_while(is_text_char), from_utf8)(i)
+// text = 1*TEXT-CHAR — lossy, see comment on string_utf8.
+pub fn text(i: &[u8]) -> IResult<&[u8], Cow<'_, str>> {
+    map(take_while(is_text_char), lossy_str)(i)
 }
 
 // TEXT-CHAR = <any CHAR except CR and LF>
@@ -178,8 +187,17 @@ pub fn is_text_char(c: u8) -> bool {
 //          ; any 7-bit US-ASCII character,
 //          ;  excluding NUL
 // From RFC5234
+//
+// Real-world IMAP servers (Dovecot, Cyrus, …) regularly emit 8-bit bytes
+// inside quoted strings and literals — typically MIME filenames in
+// non-UTF-8 encodings like Latin-1 or ISO-8859-9 (Turkish). RFC 6855 /
+// IMAP4rev2 (RFC 9051) formally allow UTF-8 in these positions. Strict
+// 7-bit rejection breaks BODYSTRUCTURE parsing on a single bad mail and
+// desyncs the entire stream. Accept any non-NUL byte and let the
+// higher-level UTF-8 conversion deal with non-UTF-8 sequences via lossy
+// decoding.
 pub fn is_char(c: u8) -> bool {
-    matches!(c, 0x01..=0x7F)
+    c != 0
 }
 
 // ----- others -----

--- a/imap-proto/src/parser/gmail.rs
+++ b/imap-proto/src/parser/gmail.rs
@@ -14,7 +14,7 @@ use super::rfc3501::flag;
 pub(crate) fn gmail_label_list(i: &[u8]) -> IResult<&[u8], Vec<Cow<'_, str>>> {
     preceded(
         tag_no_case("X-GM-LABELS "),
-        parenthesized_list(map(alt((flag, quoted_utf8)), Cow::Borrowed)),
+        parenthesized_list(alt((map(flag, Cow::Borrowed), quoted_utf8))),
     )(i)
 }
 

--- a/imap-proto/src/parser/rfc2087.rs
+++ b/imap-proto/src/parser/rfc2087.rs
@@ -4,8 +4,6 @@
 //! IMAP4 QUOTA extension
 //!
 
-use std::borrow::Cow;
-
 use nom::{
     branch::alt,
     bytes::streaming::{tag, tag_no_case},
@@ -30,7 +28,7 @@ pub(crate) fn quota(i: &[u8]) -> IResult<&[u8], Response<'_>> {
     let (rest, (_, _, root_name, _, resources)) = tuple((
         tag_no_case("QUOTA"),
         space1,
-        map(astring_utf8, Cow::Borrowed),
+        astring_utf8,
         space1,
         quota_list,
     ))(i)?;
@@ -65,7 +63,7 @@ pub(crate) fn quota_resource_name(i: &[u8]) -> IResult<&[u8], QuotaResourceName<
     alt((
         map(tag_no_case("STORAGE"), |_| QuotaResourceName::Storage),
         map(tag_no_case("MESSAGE"), |_| QuotaResourceName::Message),
-        map(map(astring_utf8, Cow::Borrowed), QuotaResourceName::Atom),
+        map(astring_utf8, QuotaResourceName::Atom),
     ))(i)
 }
 
@@ -77,8 +75,8 @@ pub(crate) fn quota_root(i: &[u8]) -> IResult<&[u8], Response<'_>> {
     let (rest, (_, _, mailbox_name, quota_root_names)) = tuple((
         tag_no_case("QUOTAROOT"),
         space1,
-        map(astring_utf8, Cow::Borrowed),
-        many0(preceded(space1, map(astring_utf8, Cow::Borrowed))),
+        astring_utf8,
+        many0(preceded(space1, astring_utf8)),
     ))(i)?;
 
     Ok((

--- a/imap-proto/src/parser/rfc2971.rs
+++ b/imap-proto/src/parser/rfc2971.rs
@@ -25,14 +25,15 @@ use crate::{
 // A single id parameter (field and value).
 // Format: string SPACE nstring
 // [RFC2971 - Formal Syntax](https://tools.ietf.org/html/rfc2971#section-4)
-fn id_param(i: &[u8]) -> IResult<&[u8], (&str, Option<&str>)> {
+#[allow(clippy::type_complexity)]
+fn id_param(i: &[u8]) -> IResult<&[u8], (Cow<'_, str>, Option<Cow<'_, str>>)> {
     separated_pair(string_utf8, space1, nstring_utf8)(i)
 }
 
 // The non-nil case of id parameter list.
 // Format: "(" #(string SPACE nstring) ")"
 // [RFC2971 - Formal Syntax](https://tools.ietf.org/html/rfc2971#section-4)
-fn id_param_list_not_nil(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
+fn id_param_list_not_nil(i: &[u8]) -> IResult<&[u8], HashMap<Cow<'_, str>, Cow<'_, str>>> {
     map(
         tuple((
             char('('),
@@ -58,7 +59,8 @@ fn id_param_list_not_nil(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
 // The id parameter list of all cases
 // id_params_list ::= "(" #(string SPACE nstring) ")" / nil
 // [RFC2971 - Formal Syntax](https://tools.ietf.org/html/rfc2971#section-4)
-fn id_param_list(i: &[u8]) -> IResult<&[u8], Option<HashMap<&str, &str>>> {
+#[allow(clippy::type_complexity)]
+fn id_param_list(i: &[u8]) -> IResult<&[u8], Option<HashMap<Cow<'_, str>, Cow<'_, str>>>> {
     alt((map(id_param_list_not_nil, Some), map(nil, |_| None)))(i)
 }
 
@@ -70,14 +72,7 @@ pub(crate) fn resp_id(i: &[u8]) -> IResult<&[u8], Response<'_>> {
         |(_id, _sp, p)| p,
     )(i)?;
 
-    Ok((
-        rest,
-        Response::Id(map.map(|m| {
-            m.into_iter()
-                .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v)))
-                .collect()
-        })),
-    ))
+    Ok((rest, Response::Id(map)))
 }
 
 #[cfg(test)]
@@ -91,7 +86,7 @@ mod tests {
             id_param(br#""name" "Cyrus""#),
             Ok((_, (name, value))) => {
                 assert_eq!(name, "name");
-                assert_eq!(value, Some("Cyrus"));
+                assert_eq!(value.as_deref(), Some("Cyrus"));
             }
         );
 
@@ -99,7 +94,7 @@ mod tests {
             id_param(br#""name" NIL"#),
             Ok((_, (name, value))) => {
                 assert_eq!(name, "name");
-                assert_eq!(value, None);
+                assert!(value.is_none());
             }
         );
     }
@@ -118,6 +113,7 @@ mod tests {
                         ("os-version", "5.5"),
                         ("support-url", "mailto:cyrus-bugs+@andrew.cmu.edu"),
                     ].into_iter()
+                    .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v)))
                     .collect()
                 );
             }
@@ -138,6 +134,7 @@ mod tests {
                         ("os-version", "5.5"),
                         ("support-url", "mailto:cyrus-bugs+@andrew.cmu.edu"),
                     ].into_iter()
+                    .map(|(k, v)| (Cow::Borrowed(k), Cow::Borrowed(v)))
                     .collect()
                 );
             }

--- a/imap-proto/src/parser/rfc3501/body_structure.rs
+++ b/imap-proto/src/parser/rfc3501/body_structure.rs
@@ -36,8 +36,8 @@ fn body_fields(i: &[u8]) -> IResult<&[u8], BodyFields<'_>> {
         i,
         BodyFields {
             param,
-            id: id.map(Cow::Borrowed),
-            description: description.map(Cow::Borrowed),
+            id,
+            description,
             transfer_encoding,
             octets,
         },
@@ -61,10 +61,10 @@ fn body_ext_1part(i: &[u8]) -> IResult<&[u8], BodyExt1Part<'_>> {
     Ok((
         i,
         BodyExt1Part {
-            md5: md5.map(Cow::Borrowed),
+            md5,
             disposition,
             language,
-            location: location.map(Cow::Borrowed),
+            location,
             extension,
         },
     ))
@@ -89,7 +89,7 @@ fn body_ext_mpart(i: &[u8]) -> IResult<&[u8], BodyExtMPart<'_>> {
             param,
             disposition,
             language,
-            location: location.map(Cow::Borrowed),
+            location,
             extension,
         },
     ))
@@ -110,20 +110,15 @@ fn body_encoding(i: &[u8]) -> IResult<&[u8], ContentEncoding<'_>> {
             )),
             char('"'),
         ),
-        map(string_utf8, |enc| {
-            ContentEncoding::Other(Cow::Borrowed(enc))
-        }),
+        map(string_utf8, ContentEncoding::Other),
     ))(i)
 }
 
 fn body_lang(i: &[u8]) -> IResult<&[u8], Option<Vec<Cow<'_, str>>>> {
     alt((
         // body language seems to refer to RFC 3066 language tags, which should be ASCII-only
-        map(nstring_utf8, |v| v.map(|s| vec![Cow::Borrowed(s)])),
-        map(
-            parenthesized_nonempty_list(map(string_utf8, Cow::Borrowed)),
-            Option::from,
-        ),
+        map(nstring_utf8, |v| v.map(|s| vec![s])),
+        map(parenthesized_nonempty_list(string_utf8), Option::from),
     ))(i)
 }
 
@@ -133,7 +128,7 @@ fn body_param(i: &[u8]) -> IResult<&[u8], BodyParams<'_>> {
         map(
             parenthesized_nonempty_list(map(
                 tuple((string_utf8, tag(" "), string_utf8)),
-                |(key, _, val)| (Cow::Borrowed(key), Cow::Borrowed(val)),
+                |(key, _, val)| (key, val),
             )),
             Option::from,
         ),
@@ -145,7 +140,7 @@ fn body_extension(i: &[u8]) -> IResult<&[u8], BodyExtension<'_>> {
         map(number, BodyExtension::Num),
         // Cannot find documentation on character encoding for body extension values.
         // So far, assuming UTF-8 seems fine, please report if you run into issues here.
-        map(nstring_utf8, |v| BodyExtension::Str(v.map(Cow::Borrowed))),
+        map(nstring_utf8, BodyExtension::Str),
         map(
             parenthesized_nonempty_list(body_extension),
             BodyExtension::List,
@@ -158,12 +153,7 @@ fn body_disposition(i: &[u8]) -> IResult<&[u8], Option<ContentDisposition<'_>>> 
         map(nil, |_| None),
         paren_delimited(map(
             tuple((string_utf8, tag(" "), body_param)),
-            |(ty, _, params)| {
-                Some(ContentDisposition {
-                    ty: Cow::Borrowed(ty),
-                    params,
-                })
-            },
+            |(ty, _, params)| Some(ContentDisposition { ty, params }),
         )),
     ))(i)
 }
@@ -181,8 +171,8 @@ fn body_type_basic(i: &[u8]) -> IResult<&[u8], BodyStructure<'_>> {
         |(ty, _, subtype, _, fields, ext)| BodyStructure::Basic {
             common: BodyContentCommon {
                 ty: ContentType {
-                    ty: Cow::Borrowed(ty),
-                    subtype: Cow::Borrowed(subtype),
+                    ty,
+                    subtype,
                     params: fields.param,
                 },
                 disposition: ext.disposition,
@@ -217,7 +207,7 @@ fn body_type_text(i: &[u8]) -> IResult<&[u8], BodyStructure<'_>> {
             common: BodyContentCommon {
                 ty: ContentType {
                     ty: Cow::Borrowed("TEXT"),
-                    subtype: Cow::Borrowed(subtype),
+                    subtype,
                     params: fields.param,
                 },
                 disposition: ext.disposition,
@@ -284,7 +274,7 @@ fn body_type_multipart(i: &[u8]) -> IResult<&[u8], BodyStructure<'_>> {
             common: BodyContentCommon {
                 ty: ContentType {
                     ty: Cow::Borrowed("MULTIPART"),
-                    subtype: Cow::Borrowed(subtype),
+                    subtype,
                     params: ext.param,
                 },
                 disposition: ext.disposition,

--- a/imap-proto/src/parser/rfc3501/mod.rs
+++ b/imap-proto/src/parser/rfc3501/mod.rs
@@ -54,10 +54,10 @@ fn status(i: &[u8]) -> IResult<&[u8], Status> {
     alt((status_ok, status_no, status_bad, status_preauth, status_bye))(i)
 }
 
-pub(crate) fn mailbox(i: &[u8]) -> IResult<&[u8], &str> {
+pub(crate) fn mailbox(i: &[u8]) -> IResult<&[u8], Cow<'_, str>> {
     map(astring_utf8, |s| {
         if s.eq_ignore_ascii_case("INBOX") {
-            "INBOX"
+            Cow::Borrowed("INBOX")
         } else {
             s
         }
@@ -115,7 +115,7 @@ fn resp_text_code_badcharset(i: &[u8]) -> IResult<&[u8], ResponseCode<'_>> {
             tag_no_case(b"BADCHARSET"),
             opt(preceded(
                 tag(b" "),
-                parenthesized_nonempty_list(map(astring_utf8, Cow::Borrowed)),
+                parenthesized_nonempty_list(astring_utf8),
             )),
         ),
         ResponseCode::BadCharset,
@@ -287,7 +287,9 @@ fn name_attribute(i: &[u8]) -> IResult<&[u8], NameAttribute<'_>> {
 }
 
 #[allow(clippy::type_complexity)]
-fn mailbox_list(i: &[u8]) -> IResult<&[u8], (Vec<NameAttribute<'_>>, Option<&str>, &str)> {
+fn mailbox_list(
+    i: &[u8],
+) -> IResult<&[u8], (Vec<NameAttribute<'_>>, Option<Cow<'_, str>>, Cow<'_, str>)> {
     map(
         tuple((
             parenthesized_list(name_attribute),
@@ -304,8 +306,8 @@ fn mailbox_data_list(i: &[u8]) -> IResult<&[u8], MailboxDatum<'_>> {
     map(preceded(tag_no_case("LIST "), mailbox_list), |data| {
         MailboxDatum::List {
             name_attributes: data.0,
-            delimiter: data.1.map(Cow::Borrowed),
-            name: Cow::Borrowed(data.2),
+            delimiter: data.1,
+            name: data.2,
         }
     })(i)
 }
@@ -314,8 +316,8 @@ fn mailbox_data_lsub(i: &[u8]) -> IResult<&[u8], MailboxDatum<'_>> {
     map(preceded(tag_no_case("LSUB "), mailbox_list), |data| {
         MailboxDatum::List {
             name_attributes: data.0,
-            delimiter: data.1.map(Cow::Borrowed),
-            name: Cow::Borrowed(data.2),
+            delimiter: data.1,
+            name: data.2,
         }
     })(i)
 }
@@ -358,10 +360,7 @@ fn status_att_list(i: &[u8]) -> IResult<&[u8], Vec<StatusAttribute>> {
 fn mailbox_data_status(i: &[u8]) -> IResult<&[u8], MailboxDatum<'_>> {
     map(
         tuple((tag_no_case("STATUS "), mailbox, tag(" "), status_att_list)),
-        |(_, mailbox, _, status)| MailboxDatum::Status {
-            mailbox: Cow::Borrowed(mailbox),
-            status,
-        },
+        |(_, mailbox, _, status)| MailboxDatum::Status { mailbox, status },
     )(i)
 }
 
@@ -510,7 +509,7 @@ fn msg_att_envelope(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
 fn msg_att_internal_date(i: &[u8]) -> IResult<&[u8], AttributeValue<'_>> {
     map(
         preceded(tag_no_case("INTERNALDATE "), nstring_utf8),
-        |date| AttributeValue::InternalDate(Cow::Borrowed(date.unwrap())),
+        |date| AttributeValue::InternalDate(date.unwrap()),
     )(i)
 }
 
@@ -612,12 +611,16 @@ fn imap_tag(i: &[u8]) -> IResult<&[u8], RequestId> {
 //     ["[" resp-text-code "]" SP] text
 // However, examples in RFC 4551 (Conditional STORE) counteract this by giving
 // examples of `resp-text` that do not include the trailing space and text.
-fn resp_text(i: &[u8]) -> IResult<&[u8], (Option<ResponseCode<'_>>, Option<&str>)> {
+#[allow(clippy::type_complexity)]
+fn resp_text(i: &[u8]) -> IResult<&[u8], (Option<ResponseCode<'_>>, Option<Cow<'_, str>>)> {
     map(tuple((opt(resp_text_code), text)), |(code, text)| {
         let res = if text.is_empty() {
             None
         } else if code.is_some() {
-            Some(&text[1..])
+            Some(match text {
+                Cow::Borrowed(s) => Cow::Borrowed(&s[1..]),
+                Cow::Owned(s) => Cow::Owned(s[1..].to_string()),
+            })
         } else {
             Some(text)
         };
@@ -626,7 +629,10 @@ fn resp_text(i: &[u8]) -> IResult<&[u8], (Option<ResponseCode<'_>>, Option<&str>
 }
 
 // an response-text if it is at the end of a response. Empty text is then allowed without the normally needed trailing space.
-fn trailing_resp_text(i: &[u8]) -> IResult<&[u8], (Option<ResponseCode<'_>>, Option<&str>)> {
+#[allow(clippy::type_complexity)]
+fn trailing_resp_text(
+    i: &[u8],
+) -> IResult<&[u8], (Option<ResponseCode<'_>>, Option<Cow<'_, str>>)> {
     map(opt(tuple((tag(b" "), resp_text))), |resptext| {
         resptext.map(|(_, tuple)| tuple).unwrap_or((None, None))
     })(i)
@@ -640,7 +646,7 @@ pub(crate) fn continue_req(i: &[u8]) -> IResult<&[u8], Response<'_>> {
         tuple((tag("+"), opt(tag(" ")), resp_text, tag("\r\n"))),
         |(_, _, text, _)| Response::Continue {
             code: text.0,
-            information: text.1.map(Cow::Borrowed),
+            information: text.1,
         },
     )(i)
 }
@@ -662,7 +668,7 @@ pub(crate) fn response_tagged(i: &[u8]) -> IResult<&[u8], Response<'_>> {
             tag,
             status,
             code: text.0,
-            information: text.1.map(Cow::Borrowed),
+            information: text.1,
         },
     )(i)
 }
@@ -679,7 +685,7 @@ fn resp_cond(i: &[u8]) -> IResult<&[u8], Response<'_>> {
         Response::Data {
             status,
             code: text.0,
-            information: text.1.map(Cow::Borrowed),
+            information: text.1,
         }
     })(i)
 }

--- a/imap-proto/src/parser/rfc4314.rs
+++ b/imap-proto/src/parser/rfc4314.rs
@@ -8,8 +8,6 @@
 //! The IMAP ACL Extension
 //!
 
-use std::borrow::Cow;
-
 use nom::{
     bytes::streaming::tag_no_case,
     character::complete::{space0, space1},
@@ -28,12 +26,7 @@ use crate::types::*;
 /// acl_response  ::= "ACL" SP mailbox SP acl_list
 /// ```
 pub(crate) fn acl(i: &[u8]) -> IResult<&[u8], Response<'_>> {
-    let (rest, (_, _, mailbox, acls)) = tuple((
-        tag_no_case("ACL"),
-        space1,
-        map(mailbox, Cow::Borrowed),
-        acl_list,
-    ))(i)?;
+    let (rest, (_, _, mailbox, acls)) = tuple((tag_no_case("ACL"), space1, mailbox, acl_list))(i)?;
 
     Ok((rest, Response::Acl(Acl { mailbox, acls })))
 }
@@ -50,9 +43,9 @@ fn acl_list(i: &[u8]) -> IResult<&[u8], Vec<AclEntry<'_>>> {
 /// ```
 fn acl_entry(i: &[u8]) -> IResult<&[u8], AclEntry<'_>> {
     let (rest, (identifier, rights)) = separated_pair(
-        map(astring_utf8, Cow::Borrowed),
+        astring_utf8,
         space1,
-        map(astring_utf8, map_text_to_rights),
+        map(astring_utf8, |s| map_text_to_rights(&s)),
     )(i)?;
 
     Ok((rest, AclEntry { identifier, rights }))
@@ -66,11 +59,11 @@ pub(crate) fn list_rights(i: &[u8]) -> IResult<&[u8], Response<'_>> {
     let (rest, (_, _, mailbox, _, identifier, _, required, optional)) = tuple((
         tag_no_case("LISTRIGHTS"),
         space1,
-        map(mailbox, Cow::Borrowed),
+        mailbox,
         space1,
-        map(astring_utf8, Cow::Borrowed),
+        astring_utf8,
         space1,
-        map(astring_utf8, map_text_to_rights),
+        map(astring_utf8, |s| map_text_to_rights(&s)),
         list_rights_optional,
     ))(i)?;
 
@@ -92,7 +85,7 @@ fn list_rights_optional(i: &[u8]) -> IResult<&[u8], Vec<AclRight>> {
         rest,
         items
             .into_iter()
-            .flat_map(|s| s.chars().map(|c| c.into()))
+            .flat_map(|s| s.chars().map(AclRight::from).collect::<Vec<_>>())
             .collect(),
     ))
 }
@@ -105,9 +98,9 @@ pub(crate) fn my_rights(i: &[u8]) -> IResult<&[u8], Response<'_>> {
     let (rest, (_, _, mailbox, _, rights)) = tuple((
         tag_no_case("MYRIGHTS"),
         space1,
-        map(mailbox, Cow::Borrowed),
+        mailbox,
         space1,
-        map(astring_utf8, map_text_to_rights),
+        map(astring_utf8, |s| map_text_to_rights(&s)),
     ))(i)?;
 
     Ok((rest, Response::MyRights(MyRights { mailbox, rights })))

--- a/imap-proto/src/parser/tests.rs
+++ b/imap-proto/src/parser/tests.rs
@@ -427,6 +427,63 @@ fn test_body_structure() {
     }
 }
 
+// Coverage for the lossy-decode (Cow::Owned) branch of resp_text:
+// a server greeting with non-UTF-8 bytes in the message text (here
+// Latin-1 "Willkommen" with ü = 0xFC) must parse without failing,
+// and the information field must come back as an owned Cow with
+// the U+FFFD replacement character.
+#[test]
+fn test_resp_text_lossy_decode_8bit() {
+    let mut response: Vec<u8> = Vec::new();
+    response.extend_from_slice(b"* OK Willk");
+    response.push(0xFC); // Latin-1 'ü', not valid UTF-8
+    response.extend_from_slice(b"ommen\r\n");
+
+    match parse_response(&response) {
+        Ok((
+            _,
+            Response::Data {
+                status: Status::Ok,
+                code: None,
+                information: Some(info),
+            },
+        )) => {
+            assert!(
+                matches!(info, Cow::Owned(_)),
+                "expected lossy Owned, got {info:?}"
+            );
+            assert_eq!(info, "Willk\u{FFFD}ommen");
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
+}
+
+// Regression: BODYSTRUCTURE with an 8-bit literal in a body parameter
+// (e.g. a MIME filename in Latin-1 / ISO-8859-9). Real-world IMAP
+// servers (Dovecot, Cyrus) emit these for mails from clients with
+// non-UTF-8 locales (Turkish "Görüntü1" is a common case from Outlook
+// for Turkish). The parser must accept the bytes via lossy UTF-8
+// decoding instead of failing the entire response.
+#[test]
+fn test_body_structure_with_8bit_literal_filename() {
+    // ("name" {8}\r\n<G>\xf6<r>\xfc<n><t>\xfc<1>) — "Görüntü1" in Latin-1
+    let mut response: Vec<u8> = Vec::new();
+    response.extend_from_slice(b"* 15 FETCH (BODYSTRUCTURE (\"image\" \"png\" (\"name\" {8}\r\n");
+    response.extend_from_slice(&[0x47, 0xF6, 0x72, 0xFC, 0x6E, 0x74, 0xFC, 0x31]);
+    response
+        .extend_from_slice(b") \"<part1@example.com>\" NIL \"base64\" 15440 NIL NIL NIL NIL))\r\n");
+    match parse_response(&response) {
+        Ok((_, Response::Fetch(_, attrs))) => {
+            assert!(
+                matches!(attrs[0], AttributeValue::BodyStructure(_)),
+                "body = {:?}",
+                attrs[0]
+            );
+        }
+        rsp => panic!("unexpected response {rsp:?}"),
+    }
+}
+
 #[test]
 fn test_status() {
     match parse_response(b"* STATUS blurdybloop (MESSAGES 231 UIDNEXT 44292)\r\n") {

--- a/tokio-imap/Cargo.toml
+++ b/tokio-imap/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "passively-maintained" }
 bytes = "1"
 futures-util = { version = "0.3.8", default-features = false }
 futures-sink = "0.3.8"
-imap-proto = { version = "0.16", path = "../imap-proto" }
+imap-proto = { version = "0.17", path = "../imap-proto" }
 nom = "7"
 pin-project-lite = "0.2.11"
 rustls-pki-types = "1"


### PR DESCRIPTION
## Summary

Real-world IMAP servers (Dovecot, Cyrus) regularly emit 8-bit bytes in BODYSTRUCTURE responses — typically MIME filenames in non-UTF-8 encodings like Latin-1 or ISO-8859-9 (e.g. Turkish `Görüntü1.png` from Outlook). The current strict 7-bit ASCII parser rejects these, breaking the parse of a single bad mail and desyncing the entire bulk fetch stream — taking down all subsequent FETCH responses in the same buffer.

Two changes:

1. **`is_char` relaxed to accept any non-NUL byte** instead of `0x01..=0x7F`. Matches real-world server behavior; RFC 6855 / IMAP4rev2 (RFC 9051) formally allow UTF-8 in these positions.

2. **`*_utf8` functions return `Cow<'_, str>` with lossy decoding** instead of `&str` with strict `from_utf8`. Affected: `string_utf8`, `nstring_utf8`, `astring_utf8`, `quoted_utf8`, `text`, plus `mailbox`, `resp_text`, `trailing_resp_text`, `mailbox_list`, `id_param`, `id_param_list_not_nil`, `id_param_list`. Callers that previously wrapped `&str` results in `Cow::Borrowed` have been simplified.

**Note**: this is a public-API change (`&str` → `Cow<'_, str>` in the `*_utf8` functions). I think it's the right tradeoff — strict UTF-8 enforcement at the parser level is too strict for real-world IMAP — but happy to discuss alternatives (e.g. parallel `*_lossy` variants, or `unsafe { from_utf8_unchecked }` to keep `&str` API).

## Reproduction

A BODYSTRUCTURE with an 8-bit filename literal:

```
* 15 FETCH (BODYSTRUCTURE ("image" "png" ("name" {8}\r\n<G><F6><r><FC><n><t><FC>1) ...
```

Where the 8 bytes after `{8}\r\n` are `0x47 0xF6 0x72 0xFC 0x6E 0x74 0xFC 0x31` (Turkish `Görüntü1` in Latin-1, valid IMAP literal but not valid UTF-8).

On master this fails with `code: TakeWhile1` because:
- `quoted` parser uses `take_while1(is_text_char)` which rejects bytes `>= 0x80`
- Even when `quoted` succeeds, `from_utf8` in `string_utf8` fails on Latin-1 sequences

With the fix the parser proceeds and the filename is decoded lossily (replacement chars for invalid UTF-8 sequences).

## Test plan

- [x] All 82 existing `imap-proto` tests pass
- [x] New regression test `test_body_structure_with_8bit_literal_filename` passes with the fix
- [x] Same test reverted-to-master state fails with the exact `TakeWhile1` error from the field bug report

Run:

```
cargo test -p imap-proto
```