### PR TITLE
Read a NIL body-fld-enc as 7bit instead of failing the response

### DIFF
--- a/src/parser/rfc3501/body_structure.rs
+++ b/src/parser/rfc3501/body_structure.rs
@@ -95,8 +95,12 @@ fn body_ext_mpart(i: &[u8]) -> IResult<&[u8], BodyExtMPart<'_>> {
     ))
 }
 
+// RFC 3501 defines `body-fld-enc` as a string, never NIL, but some servers send
+// NIL for a part with no Content-Transfer-Encoding header (seen on Apple iCloud;
+// imap-codec records the same from maddy). RFC 2045 s6.1 defaults that to 7bit.
 fn body_encoding(i: &[u8]) -> IResult<&[u8], ContentEncoding<'_>> {
     alt((
+        map(nil, |_| ContentEncoding::SevenBit),
         delimited(
             char('"'),
             alt((
@@ -416,6 +420,34 @@ mod tests {
                         (Cow::Borrowed("FILENAME"), Cow::Borrowed("pages.pdf"))
                     ])
                 });
+            }
+        );
+    }
+
+    // Apple iCloud sends NIL here, which the grammar does not allow.
+    #[test]
+    fn test_body_encoding_nil_is_seven_bit() {
+        assert_matches!(
+            body_encoding(br"NIL"),
+            Ok((EMPTY, ContentEncoding::SevenBit))
+        );
+    }
+
+    // The whole response has to survive it, not just the field.
+    #[test]
+    fn test_body_structure_multipart_with_nil_encoding() {
+        const BODY: &[u8] = br#"(("text" "plain" ("CHARSET" "UTF-8") NIL NIL NIL 1694 51 NIL NIL NIL NIL)("text" "html" ("CHARSET" "UTF-8") NIL NIL "quoted-printable" 5750 77 NIL NIL NIL NIL) "alternative" ("BOUNDARY" "94eb2c1235681e93cc0568edba59") NIL NIL NIL)"#;
+
+        assert_matches!(
+            body(BODY),
+            Ok((EMPTY, BodyStructure::Multipart { bodies, .. })) => {
+                assert_eq!(bodies.len(), 2);
+                assert_matches!(
+                    &bodies[0],
+                    BodyStructure::Text { other, .. } => {
+                        assert_eq!(other.transfer_encoding, ContentEncoding::SevenBit);
+                    }
+                );
             }
         );
     }


### PR DESCRIPTION
Apple iCloud sends `NIL` in the `body-fld-enc` slot for a part that carried no `Content-Transfer-Encoding` header:

```
* 80 FETCH (UID 111 ... BODYSTRUCTURE (("text" "plain" ("CHARSET" "UTF-8") NIL NIL NIL 1694 51 NIL NIL NIL NIL)
                                       ("text" "html" ("CHARSET" "UTF-8") NIL NIL "quoted-printable" 5750 77 ...)
                                       "alternative" ...))
```

RFC 3501 defines `body-fld-enc` as a string, so this is the server being wrong. But the cost of rejecting it is high and hard to diagnose: `body_encoding` fails, the whole `parse_response` fails, and in `async-imap` that becomes a connection-level `io::Error` while `return_block` puts the offending bytes back in the buffer. Every later poll re-parses the same bytes and fails identically, so the connection cannot recover in session.

On a real iCloud account this was 1 message out of 308, and it made a full `UID FETCH 1:*` unusable for its mailbox.

RFC 2045 s6.1 makes 7bit the default when the header is absent, which is exactly the case the server is describing, so this reads `NIL` as `ContentEncoding::SevenBit`.

Precedent: `imap-codec` carries the same allowance as `quirk_body_fld_enc_nil_to_empty`, enabled by default, documented as observed in maddy. So iCloud is not the only server doing this.

Happy to map it to `ContentEncoding::Other("")` instead if you would rather keep "the server said nothing" distinguishable from "the server said 7BIT" -- 7bit seemed more useful to consumers, since it is what they would have to substitute anyway.

Adds two tests: the field in isolation, and the multipart above end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)